### PR TITLE
Update EL10 template to Alma repos; add aarch64 EL10 config

### DIFF
--- a/terra-el-dev.tpl
+++ b/terra-el-dev.tpl
@@ -33,40 +33,37 @@ module_platform_id=platform:el10
 user_agent={{ user_agent }}
 
 [baseos]
-name=CentOS Stream $releasever - BaseOS
-#baseurl=http://mirror.stream.centos.org/$releasever-stream/BaseOS/$basearch/os/
-metalink=https://mirrors.centos.org/metalink?repo=centos-baseos-$releasever-stream&arch=$basearch&protocol=https,http
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official-SHA256
-gpgcheck=1
-countme=1
+name=AlmaLinux Kitten $releasever - BaseOS
+mirrorlist=https://kitten.mirrors.almalinux.org/mirrorlist/$releasever-kitten/baseos
+# baseurl=https://kitten.repo.almalinux.org/$releasever-kitten/BaseOS/$basearch/os/
 enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+skip_if_unavailable=False
 
 [appstream]
-name=CentOS Stream $releasever - AppStream
-#baseurl=http://mirror.stream.centos.org/$releasever-stream/AppStream/$basearch/os/
-metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-$releasever-stream&arch=$basearch&protocol=https,http
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official-SHA256
-gpgcheck=1
-countme=1
+name=AlmaLinux Kitten $releasever - AppStream
+mirrorlist=https://kitten.mirrors.almalinux.org/mirrorlist/$releasever-kitten/appstream
+# baseurl=https://kitten.repo.almalinux.org/$releasever-kitten/AppStream/$basearch/os/
 enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
 
 [crb]
-name=CentOS Stream $releasever - CRB
-#baseurl=http://mirror.stream.centos.org/$releasever-stream/CRB/$basearch/os/
-metalink=https://mirrors.centos.org/metalink?repo=centos-crb-$releasever-stream&arch=$basearch&protocol=https,http
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official-SHA256
-gpgcheck=1
-countme=1
+name=AlmaLinux Kitten $releasever - CRB
+mirrorlist=https://kitten.mirrors.almalinux.org/mirrorlist/$releasever-kitten/crb
+# baseurl=https://kitten.repo.almalinux.org/$releasever-kitten/CRB/$basearch/os/
 enabled=1
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
 
 [extras-common]
-name=CentOS Stream $releasever - Extras packages
-#baseurl=http://mirror.stream.centos.org/SIGs/$releasever-stream/extras/$basearch/extras-common/
-metalink=https://mirrors.centos.org/metalink?repo=centos-extras-sig-extras-common-$releasever-stream&arch=$basearch&protocol=https,http
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
-gpgcheck=1
+name=AlmaLinux Kitten $releasever - Extras
+mirrorlist=https://kitten.mirrors.almalinux.org/mirrorlist/$releasever-kitten/extras-common
+# baseurl=https://kitten.repo.almalinux.org/$releasever-kitten/extras-common/$basearch/os/
 enabled=1
-skip_if_unavailable=False
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
 
 [terra]
 name=Terra EL $releasever
@@ -94,11 +91,7 @@ priority=150
 
 [epel]
 name=Extra Packages for Enterprise Linux $releasever - $basearch
-# It is much more secure to use the metalink, but if you wish to use a local mirror
-# place its address here.
-#baseurl=https://dl.fedoraproject.org/pub/epel/$releasever_major${releasever_minor:+.$releasever_minor}/Everything/$basearch/
-metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever_major${releasever_minor:+.$releasever_minor}&arch=$basearch
-gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever_major
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-{{ releasever_major }}&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-{{ releasever_major }}
 gpgcheck=1
 countme=1
-"""

--- a/terra-el-dev.tpl
+++ b/terra-el-dev.tpl
@@ -38,7 +38,7 @@ mirrorlist=https://kitten.mirrors.almalinux.org/mirrorlist/$releasever-kitten/ba
 # baseurl=https://kitten.repo.almalinux.org/$releasever-kitten/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-10
 skip_if_unavailable=False
 
 [appstream]
@@ -47,7 +47,7 @@ mirrorlist=https://kitten.mirrors.almalinux.org/mirrorlist/$releasever-kitten/ap
 # baseurl=https://kitten.repo.almalinux.org/$releasever-kitten/AppStream/$basearch/os/
 enabled=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-10
 
 [crb]
 name=AlmaLinux Kitten $releasever - CRB
@@ -55,7 +55,7 @@ mirrorlist=https://kitten.mirrors.almalinux.org/mirrorlist/$releasever-kitten/cr
 # baseurl=https://kitten.repo.almalinux.org/$releasever-kitten/CRB/$basearch/os/
 enabled=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-10
 
 [extras-common]
 name=AlmaLinux Kitten $releasever - Extras
@@ -63,7 +63,7 @@ mirrorlist=https://kitten.mirrors.almalinux.org/mirrorlist/$releasever-kitten/ex
 # baseurl=https://kitten.repo.almalinux.org/$releasever-kitten/extras-common/$basearch/os/
 enabled=1
 gpgcheck=1
-gpgkey=file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-10
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-10
 
 [terra]
 name=Terra EL $releasever
@@ -91,7 +91,9 @@ priority=150
 
 [epel]
 name=Extra Packages for Enterprise Linux $releasever - $basearch
-metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-{{ releasever_major }}&arch=$basearch
-gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-{{ releasever_major }}
+metalink=https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-$releasever
 gpgcheck=1
 countme=1
+
+"""

--- a/terra-el10-dev-aaarch64.cfg
+++ b/terra-el10-dev-aaarch64.cfg
@@ -1,0 +1,8 @@
+config_opts["koji_primary_repo"] = "epel"
+
+
+config_opts['releasever'] = '10'
+config_opts['target_arch'] = 'aarch64'
+config_opts['legal_host_arches'] = ('aarch64',)
+
+include('templates/terra-el-dev.tpl')


### PR DESCRIPTION
We've been using CentOS Stream 10's development version so far for bootstrap and repos; we'll likely switch to Alma once EL10 is released. Alma has released their development EL10 version, so this PR swaps repos to use it.
DO NOT MERGE until https://github.com/terrapkg/builder/pull/4 is merged; it will break.