### PR TITLE
chore(ci): No longer using dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
         run: cp -v mock-configs/*.tpl /etc/mock/templates/
 
       - name: Build with Andaman
-        run: anda build terra/mock-configs -c mock-configs/terra-el10-dev-x86_64.cfg
+        run: anda build terra/mock-configs -c mock-configs/terra-el10-x86_64.cfg
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Probably needs #12 and Builder rebuilds? 