### PR TITLE
Switch riscv64 to RISE RISC-V Runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         releasever: [rawhide, 44, 43, 42]
         arch: [x86_64, aarch64, i386, riscv64]
       fail-fast: false
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-22.04-arm' || matrix.arch == 'riscv64' && 'banana-pi-f3' || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.arch == 'aarch64' && 'ubuntu-22.04-arm') || (matrix.arch == 'riscv64' && 'ubuntu-24.04-riscv') || 'ubuntu-latest' }}
     container:
       image: ghcr.io/terrapkg/builder:f${{ matrix.releasever }}
       options: --cap-add=SYS_ADMIN --privileged
@@ -62,7 +62,7 @@ jobs:
       matrix:
         arch: [x86_64, aarch64, riscv64]
       fail-fast: false
-    runs-on: ${{ matrix.arch == 'aarch64' && 'ubuntu-22.04-arm' || matrix.arch == 'riscv64' && 'banana-pi-f3' || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.arch == 'aarch64' && 'ubuntu-22.04-arm') || (matrix.arch == 'riscv64' && 'ubuntu-24.04-riscv') || 'ubuntu-latest' }}
     container:
       image: ghcr.io/terrapkg/builder:el10
       options: --cap-add=SYS_ADMIN --privileged


### PR DESCRIPTION
Migrate riscv64 builds to RISE RISC-V Runners, which provide access to a larger pool of hardware. This applies to both the build and build-el10 jobs.

More documentation at https://riseproject-dev.github.io/riscv-runner/

You'll also need to install https://github.com/apps/rise-risc-v-runners on your organization to have access to these runners.